### PR TITLE
feat: 채팅 메시지 변환/저장 로직 구현 및 ChatServer에 연동

### DIFF
--- a/src/main/java/com/Repository/UserRepository.java
+++ b/src/main/java/com/Repository/UserRepository.java
@@ -3,9 +3,15 @@ package com.Repository;
 import com.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUsername(String username);
 
     User findByUsername(String username);
+
+    //LoginId 칼럼으로 사용자 찾는 함수
+    Optional<User> findByLoginId(String loginId);
+
 }

--- a/src/main/java/com/entity/ChatMessage.java
+++ b/src/main/java/com/entity/ChatMessage.java
@@ -23,6 +23,12 @@ public class ChatMessage {
     @Enumerated(EnumType.STRING)
     private User.RoomType room;
 
+    @Enumerated(EnumType.STRING)
+    private User.RoleType role;
+
+    @Column(nullable = false)
+    private String nickname;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/entity/User.java
+++ b/src/main/java/com/entity/User.java
@@ -13,13 +13,14 @@ import java.time.LocalDateTime;
 public class User {
 
     // 내부 ENUM
-    public enum Role {
+    public enum RoleType {
         USER, ADMIN
     }
 
     public enum RoomType {
         A, B
     }
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,7 +37,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
+    private RoleType role;
 
     @Column(nullable = false)
     private int floor;

--- a/src/main/java/com/service/ChatMessageService.java
+++ b/src/main/java/com/service/ChatMessageService.java
@@ -1,0 +1,67 @@
+package com.service;
+
+import com.Repository.ChatMessageRepository;
+import com.Repository.UserRepository;
+import com.entity.ChatMessage;
+import com.entity.User;
+import com.socket.server.SocketMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void saveChat(SocketMessage msg) {
+
+        // 1. sender(login_id)로 User 조회
+        User user = null;
+        if (msg.getSender() != null) {
+            user = userRepository.findByLoginId(msg.getSender())
+                    .orElse(null); // 못 찾으면 null 허용
+        }
+
+        // 2. room 문자열 -> ENUM 변환
+        User.RoomType roomType = null;
+        if (msg.getRoom() != null) {
+            try {
+                roomType = User.RoomType.valueOf(msg.getRoom().toUpperCase());
+            } catch (Exception e) {
+                System.out.println("[WARN] Invalid room: " + msg.getRoom());
+            }
+        }
+
+        // 3. role 문자열 -> ENUM 변환
+        User.RoleType roleType = null;
+        if (msg.getRole() != null) {
+            try {
+                roleType = User.RoleType.valueOf(msg.getRole().toUpperCase());
+            } catch (Exception e) {
+                System.out.println("[WARN] Invalid role: " + msg.getRole());
+            }
+        }
+
+        // 4. username을 nickname으로 사용
+        String nickname = (user != null) ? user.getUsername() : msg.getSender();
+
+        // 5. floor 처리
+        int floor = (msg.getFloor() != null) ? msg.getFloor() : 0;
+
+        // 6. ChatMessage 엔티티 생성
+        ChatMessage chatMessage = ChatMessage.builder()
+                .floor(floor)
+                .room(roomType)
+                .role(roleType)
+                .nickname(nickname)
+                .user(user)
+                .message(msg.getMsg())
+                .build();
+
+        chatMessageRepository.save(chatMessage);
+    }
+}

--- a/src/main/java/com/socket/server/ChatServer.java
+++ b/src/main/java/com/socket/server/ChatServer.java
@@ -1,6 +1,7 @@
 package com.socket.server;
 // ServerSocket 열기 + 브로드캐스트 + 클라이언트 리스트 관리
 
+import com.service.ChatMessageService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -15,9 +16,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ChatServer {
 
     private final int port = 5050;
+    private final ChatMessageService chatMessageService;
 
     // 접속 중인 클라이언트 목록
     private final List<ClientHandler> clients = new CopyOnWriteArrayList<>();
+
+    public ChatServer(ChatMessageService chatMessageService) {
+        this.chatMessageService = chatMessageService;
+    }
 
     public void start() {
         log.info("[SERVER] 도서관 채팅 서버 시작, 포트: {}", port);
@@ -30,7 +36,8 @@ public class ChatServer {
                 log.info("[SERVER] 새 클라이언트 접속: {}", clientSocket.getRemoteSocketAddress());
 
                 // 2) 핸들러 생성 후 리스트에 추가
-                ClientHandler handler = new ClientHandler(clientSocket, this);
+                ClientHandler handler =
+                        new ClientHandler(clientSocket, this, chatMessageService);
                 clients.add(handler);
 
                 // 3) 스레드로 실행


### PR DESCRIPTION
### 작업 개요
- SocketMessage → ChatMessage 변환 로직 구현
- ChatMessage 엔티티(role, nickname 등) 필드 확장
- JOIN 시 floor/room/role/sender 바인딩 및 User 조회
- CHAT 수신 시 ChatMessage 저장 서비스 연동
- ClientHandler · ChatServer에 DB 저장 로직 적용

### 주요 변경 사항
- ChatMessageService 추가 및 SocketMessage 매핑 로직 구현
- ClientHandler에서 CHAT 타입 처리 시 DB 저장 로직 호출
- ChatServer에서 ClientHandler 생성 시 ChatMessageService DI 적용
- chat_messages 테이블에 채팅 로그 저장 확인
- 닉네임 username 기반 저장 및 User FK 연동

### 검증 내용
- 콘솔 클라이언트 2개로 JOIN·CHAT 테스트 수행
- chat_messages 테이블에 메시지가 정상적으로 누적되는 것 확인
- 시스템 메시지 및 브로드캐스트 정상 동작 확인

### 결과
CHAT 흐름이 실제 서버/DB와 완전히 연동됨.
